### PR TITLE
Implement improvements to the Yelp service

### DIFF
--- a/client/app/channels/food/services/services.js
+++ b/client/app/channels/food/services/services.js
@@ -17,7 +17,8 @@ angular.module('platypus.foodServices', [])
           var url =     'http://api.yelp.com/v2/search';
           var params = {
             callback:                 'angular.callbacks._0',
-            location:                 'San+Francisco',
+            ll:                       '37.7836963,-122.4096779',
+            radius_filter:            '3219',
             oauth_consumer_key:       'UVOv68GWWuYUEHgIOs2kbA', // consumer key
             oauth_token:              'rGxuTEJtPFiQswZ3ai4up_qKrDBWPlQy', //Token
             oauth_signature_method:   'HMAC-SHA1',


### PR DESCRIPTION
Yelp service now searches around 2 miles of Hack Reactor instead of SF in general.
